### PR TITLE
WPI reporting logs + rm recursion

### DIFF
--- a/message_store/subscriptions/progress_reporter.py
+++ b/message_store/subscriptions/progress_reporter.py
@@ -11,7 +11,7 @@ class ProgressReporter:
     The default  for the progress reporter 15 secs
     """
 
-    def __init__(self, report_interval_in_seconds=15):
+    def __init__(self, report_interval_in_seconds=10):
         self._reportIntervalInSeconds = report_interval_in_seconds
         self._progressTask: Optional[asyncio.Task[None]]
         self._progressTask = None

--- a/message_store/subscriptions/progress_reporter.py
+++ b/message_store/subscriptions/progress_reporter.py
@@ -22,12 +22,12 @@ class ProgressReporter:
         )
 
     async def _report_progress(self, jetstream_message: Msg):
-        await asyncio.sleep(self._reportIntervalInSeconds)
-        await jetstream_message.in_progress()
-        message_store_logger.debug(
-            f"Sent +WPI to jetstream for message with seq: {jetstream_message.metadata.sequence.stream}, subject {jetstream_message.subject} from stream {jetstream_message.metadata.stream}"
-        )
-        await self._report_progress(jetstream_message)
+        while True:
+            await asyncio.sleep(self._reportIntervalInSeconds)
+            await jetstream_message.in_progress()
+            message_store_logger.debug(
+                f"Sent +WPI to jetstream for message with seq: {jetstream_message.metadata.sequence.stream}, subject {jetstream_message.subject} from stream {jetstream_message.metadata.stream}"
+            )
 
     def stop_reporting_progress(self):
         if self._progressTask is not None:

--- a/message_store/subscriptions/progress_reporter.py
+++ b/message_store/subscriptions/progress_reporter.py
@@ -24,7 +24,13 @@ class ProgressReporter:
     async def _report_progress(self, jetstream_message: Msg):
         while True:
             await asyncio.sleep(self._reportIntervalInSeconds)
-            await jetstream_message.in_progress()
+            try:
+                await jetstream_message.in_progress()
+            except Exception as e:
+                message_store_logger.error(
+                    f"Error sending +WPI to jetstream for message with seq: {jetstream_message.metadata.sequence.stream}, subject {jetstream_message.subject} from stream {jetstream_message.metadata.stream}. Error: {e}"
+                )
+                continue
             message_store_logger.debug(
                 f"Sent +WPI to jetstream for message with seq: {jetstream_message.metadata.sequence.stream}, subject {jetstream_message.subject} from stream {jetstream_message.metadata.stream}"
             )


### PR DESCRIPTION
https://zencastr.atlassian.net/browse/PL-5207

Noticed that the WPI publishes may be failing silently inside a task, this PR adds a log whenever an exception occurs during WPI publish. Also removed recursive calls since python has a recursion limit of 1000 calls.