### PR TITLE
Add `NoStreamResponseError` as a retry condition

### DIFF
--- a/message_store/message_store.py
+++ b/message_store/message_store.py
@@ -99,7 +99,7 @@ class MessageStore:
                 timeout=timeout_in_seconds,
             ),
             max_retries=3,
-            is_retriable=lambda e: hasattr(e, "code") and e.code == "503",
+            is_retriable=lambda e: hasattr(e, "code") and e.code == 503,
             initial_backoff_time_in_seconds=0.25,
         )
 

--- a/message_store/message_store.py
+++ b/message_store/message_store.py
@@ -112,6 +112,7 @@ class MessageStore:
             initial_backoff_time_in_seconds=5,
             is_retriable=lambda e: isinstance(e, nats.errors.TimeoutError)
             or isinstance(e, asyncio.TimeoutError)
+            or isinstance(e, nats.js.errors.NoStreamResponseError)
             or (
                 hasattr(e, "code")
                 and (


### PR DESCRIPTION
Changes:
- Update `is_retriable` in `publish_message` since error codes are numbers
- Add `nats.js.errors.NoStreamResponseError` as valid retry condition in `fetch`

@ruidfigueiredo should retry conditions be shared between `fetch` and `publish_message`? They currently diverge