### PR TITLE
Story/pl 5366/task/pl 5368 until seq in fetch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,6 @@ cython_debug/
 #.idea/
 
 bin
+
+.venv
+.python-version

--- a/message_store/projections/fetch.py
+++ b/message_store/projections/fetch.py
@@ -9,7 +9,7 @@ class Fetch:
         self._jetstream_client = jetstream_client
         self._nats_subject_prefix = nats_subject_prefix
 
-    async def fetch(self, subject: str, projection: Projection, until_seq: int = None):        
+    async def fetch(self, subject: str, projection: Projection, until_seq: int | None = None):        
         subscription = await self._jetstream_client.subscribe(
             f"{self._nats_subject_prefix}{subject}", ordered_consumer=True
         )

--- a/message_store/projections/fetch.py
+++ b/message_store/projections/fetch.py
@@ -9,39 +9,46 @@ class Fetch:
         self._jetstream_client = jetstream_client
         self._nats_subject_prefix = nats_subject_prefix
 
-    async def fetch(self, subject: str, projection: Projection):
+    async def fetch(self, subject: str, projection: Projection, until_seq: int = None):        
         subscription = await self._jetstream_client.subscribe(
             f"{self._nats_subject_prefix}{subject}", ordered_consumer=True
         )
-        consumer_info = await subscription.consumer_info()
-        if not self._has_consumer_any_messages(consumer_info):
-            return projection.get_result()
+        try:
+            consumer_info = await subscription.consumer_info()
+            if not self._has_consumer_any_messages(consumer_info):                
+                return projection.get_result()
 
-        total_messages_in_stream = self._get_total_number_of_messages_in_consumer(
-            consumer_info
-        )
-        processed_count = 0
-        async for jetstream_message in subscription.messages:
-            message = MessageFromSubscription.create_from_js_message(
-                self._nats_subject_prefix, jetstream_message
+            total_messages_in_stream = self._get_total_number_of_messages_in_consumer(
+                consumer_info
             )
-            projection.handle(message.type, message)
-            processed_count += 1
-            if processed_count == total_messages_in_stream:                                
-                await subscription.unsubscribe()
-                await self.ensure_consumer_is_deleted(subject, consumer_name=consumer_info.name)                
+            processed_count = 0            
+            async for jetstream_message in subscription.messages:                
+                # If we have a sequence number to stop at, we should stop processing messages
+                # once we reach that sequence number (inclusive)
+                if until_seq is not None and jetstream_message.metadata.sequence.stream > until_seq:
+                    break
 
+                message = MessageFromSubscription.create_from_js_message(
+                    self._nats_subject_prefix, jetstream_message
+                )
+                projection.handle(message.type, message)
+                processed_count += 1
+                if processed_count == total_messages_in_stream:                                
+                    break
+        finally:
+            await subscription.unsubscribe()
+            await self._ensure_consumer_is_deleted(subject, consumer_name=consumer_info.name)                
 
         return projection.get_result()
 
     def _get_total_number_of_messages_in_consumer(self, consumer_info: ConsumerInfo):
-        return consumer_info.num_pending or 0 + consumer_info.delivered.consumer_seq if consumer_info.delivered else 0
+        return (consumer_info.num_pending or 0) + (consumer_info.delivered.consumer_seq if consumer_info.delivered else 0)
 
     def _has_consumer_any_messages(self, consumer_info: ConsumerInfo):
         return self._get_total_number_of_messages_in_consumer(consumer_info) > 0
 
 
-    async def ensure_consumer_is_deleted(self, subject: str, consumer_name: str) -> None:
+    async def _ensure_consumer_is_deleted(self, subject: str, consumer_name: str) -> None:
         """
         Jetstream (at least synadia) sometimes takes its time to delete the consumer even when it's ephemeral
         This method will try to actively delete the consumer

--- a/test/fetch_test.py
+++ b/test/fetch_test.py
@@ -1,0 +1,126 @@
+import unittest
+import unittest.mock as mock
+from message_store.projections.fetch import Fetch, Projection
+import asyncio
+import json
+
+
+class FetchTests(unittest.TestCase):
+    def test_async_fetch_no_messages_returns_init(self):
+        projection = mock.Mock()
+        projection.get_result.return_value = {"result": "init"}
+        fetch = TestableFetch()
+
+        result = asyncio.run(fetch.fetch("some_subject.123", projection))
+
+        self.assertEqual(result, {"result": "init"})
+        fetch.ensure_consumer_is_deleted_mock.assert_called_once()
+
+    def test_async_fetch_with_one_message_count_message_projection_returns_one(self):
+        projection = Projection(
+            init=lambda: {"count": 0},
+            handlers={"TheEvent": lambda state, _: {"count": state["count"] + 1}},
+        )
+        fetch = TestableFetch(
+            messages_to_return=[{"type": "TheEvent", "data": {}}],
+        )
+
+        result = asyncio.run(fetch.fetch("subject", projection))
+
+        fetch.ensure_consumer_is_deleted_mock.assert_called_once()
+        self.assertEqual(result, {"count": 1})
+
+    def test_async_fetch_with_three_messages_count_message_projection_returns_three(
+        self,
+    ):
+        projection = Projection(
+            init=lambda: {"count": 0},
+            handlers={"TheEvent": lambda state, _: {"count": state["count"] + 1}},
+        )
+        fetch = TestableFetch(
+            messages_to_return=[
+                {"type": "TheEvent", "data": {}},
+                {"type": "TheEvent", "data": {}},
+                {"type": "TheEvent", "data": {}},
+                {"type": "UnrelatedEvent", "data": {}},
+            ],
+        )
+
+        result = asyncio.run(fetch.fetch("some_subject.123", projection))
+
+        fetch.ensure_consumer_is_deleted_mock.assert_called_once()
+        self.assertEqual(result, {"count": 3})
+
+    def test_async_fetch_with_three_messages_count_and_until_seq_2_message_projection_returns_two(
+        self,
+    ):
+        projection = Projection(
+            init=lambda: {"count": 0},
+            handlers={"TheEvent": lambda state, _: {"count": state["count"] + 1}},
+        )
+        fetch = TestableFetch(
+            messages_to_return=[
+                {"type": "TheEvent", "data": {}},  # seq 1
+                {"type": "TheEvent", "data": {}},  # seq 2
+                {"type": "TheEvent", "data": {}},  # seq 3
+                {"type": "UnrelatedEvent", "data": {}},  # seq 4
+            ],
+        )
+
+        result = asyncio.run(fetch.fetch("some_subject.123", projection, until_seq=2))
+
+        fetch.ensure_consumer_is_deleted_mock.assert_called_once()
+        self.assertEqual(result, {"count": 2})
+
+    def test_async_fetch_with_three_messages_count_and_until_seq_3_unrelated_message_affects_count_returns_two(
+        self,
+    ):
+        projection = Projection(
+            init=lambda: {"count": 0},
+            handlers={"TheEvent": lambda state, _: {"count": state["count"] + 1}},
+        )
+        fetch = TestableFetch(
+            messages_to_return=[
+                {"type": "TheEvent", "data": {}},  # seq 1
+                {"type": "UnrelatedEvent", "data": {}},  # seq 2
+                {"type": "TheEvent", "data": {}},  # seq 3
+                {"type": "TheEvent", "data": {}},  # seq 4
+            ],
+        )
+
+        result = asyncio.run(fetch.fetch("some_subject.123", projection, until_seq=3))
+
+        fetch.ensure_consumer_is_deleted_mock.assert_called_once()
+        self.assertEqual(result, {"count": 2})
+
+
+class TestableFetch(Fetch):
+    def __init__(self, messages_to_return=[]):
+        self.ensure_consumer_is_deleted_mock = mock.AsyncMock()
+        self._ensure_consumer_is_deleted = self.ensure_consumer_is_deleted_mock
+        self.jetstrean_client_mock = mock.Mock(
+            subscribe=mock.AsyncMock(
+                return_value=mock.AsyncMock(
+                    messages=self._create_messages_iterator(
+                        subject="some_subject_value_not_used",
+                        messages=messages_to_return,
+                    ),
+                    consumer_info=mock.AsyncMock(
+                        return_value=mock.Mock(
+                            num_pending=len(messages_to_return), delivered=None
+                        )
+                    ),
+                )
+            )
+        )
+        super().__init__(self.jetstrean_client_mock, "the_prefix_doesnt_matter")
+
+    async def _create_messages_iterator(self, subject, messages):
+        for index, message in enumerate(messages):
+            yield mock.Mock(
+                subject=subject,
+                data=json.dumps(message).encode(),
+                timestamp=mock.Mock(),
+                num_delivered=0,
+                metadata=mock.Mock(sequence=mock.Mock(stream=index + 1)),
+            )

--- a/test/fetch_test.py
+++ b/test/fetch_test.py
@@ -15,7 +15,7 @@ class FetchTests(unittest.TestCase):
 
         fetch.ensure_consumer_is_deleted_mock.assert_called_once()
         fetch.subscribe_mock.assert_called_once_with(
-            f"the_nats_env_subject_prefix.some_subject.123", ordered_consumer=True
+            "the_nats_env_subject_prefix.some_subject.123", ordered_consumer=True
         )
         self.assertEqual(result, {"result": "init"})
 
@@ -32,7 +32,7 @@ class FetchTests(unittest.TestCase):
         result = asyncio.run(fetch.fetch("subject", projection))
 
         fetch.subscribe_mock.assert_called_once_with(
-            f"the_nats_env_subject_prefix.subject", ordered_consumer=True
+            "the_nats_env_subject_prefix.subject", ordered_consumer=True
         )
         fetch.ensure_consumer_is_deleted_mock.assert_called_once()
         self.assertEqual(result, {"count": 1})
@@ -57,7 +57,7 @@ class FetchTests(unittest.TestCase):
         result = asyncio.run(fetch.fetch("some_subject.123", projection))
 
         fetch.subscribe_mock.assert_called_once_with(
-            f"the_nats_env_subject_prefix.some_subject.123", ordered_consumer=True
+            "the_nats_env_subject_prefix.some_subject.123", ordered_consumer=True
         )
         fetch.ensure_consumer_is_deleted_mock.assert_called_once()
         self.assertEqual(result, {"count": 3})
@@ -82,7 +82,7 @@ class FetchTests(unittest.TestCase):
         result = asyncio.run(fetch.fetch("some_subject.123", projection, until_seq=2))
 
         fetch.subscribe_mock.assert_called_once_with(
-            f"the_nats_env_subject_prefix.some_subject.123", ordered_consumer=True
+            "the_nats_env_subject_prefix.some_subject.123", ordered_consumer=True
         )
         fetch.ensure_consumer_is_deleted_mock.assert_called_once()
         self.assertEqual(result, {"count": 2})
@@ -107,7 +107,7 @@ class FetchTests(unittest.TestCase):
         result = asyncio.run(fetch.fetch("some_subject.123", projection, until_seq=3))
 
         fetch.subscribe_mock.assert_called_once_with(
-            f"the_nats_env_subject_prefix.some_subject.123", ordered_consumer=True
+            "the_nats_env_subject_prefix.some_subject.123", ordered_consumer=True
         )
         fetch.ensure_consumer_is_deleted_mock.assert_called_once()
         self.assertEqual(result, {"count": 2})

--- a/test/fetch_test.py
+++ b/test/fetch_test.py
@@ -9,12 +9,15 @@ class FetchTests(unittest.TestCase):
     def test_async_fetch_no_messages_returns_init(self):
         projection = mock.Mock()
         projection.get_result.return_value = {"result": "init"}
-        fetch = TestableFetch()
+        fetch = TestableFetch(nats_prefix="the_nats_env_subject_prefix.")
 
         result = asyncio.run(fetch.fetch("some_subject.123", projection))
 
-        self.assertEqual(result, {"result": "init"})
         fetch.ensure_consumer_is_deleted_mock.assert_called_once()
+        fetch.subscribe_mock.assert_called_once_with(
+            f"the_nats_env_subject_prefix.some_subject.123", ordered_consumer=True
+        )
+        self.assertEqual(result, {"result": "init"})
 
     def test_async_fetch_with_one_message_count_message_projection_returns_one(self):
         projection = Projection(
@@ -23,10 +26,14 @@ class FetchTests(unittest.TestCase):
         )
         fetch = TestableFetch(
             messages_to_return=[{"type": "TheEvent", "data": {}}],
+            nats_prefix="the_nats_env_subject_prefix.",
         )
 
         result = asyncio.run(fetch.fetch("subject", projection))
 
+        fetch.subscribe_mock.assert_called_once_with(
+            f"the_nats_env_subject_prefix.subject", ordered_consumer=True
+        )
         fetch.ensure_consumer_is_deleted_mock.assert_called_once()
         self.assertEqual(result, {"count": 1})
 
@@ -38,6 +45,7 @@ class FetchTests(unittest.TestCase):
             handlers={"TheEvent": lambda state, _: {"count": state["count"] + 1}},
         )
         fetch = TestableFetch(
+            nats_prefix="the_nats_env_subject_prefix.",
             messages_to_return=[
                 {"type": "TheEvent", "data": {}},
                 {"type": "TheEvent", "data": {}},
@@ -48,6 +56,9 @@ class FetchTests(unittest.TestCase):
 
         result = asyncio.run(fetch.fetch("some_subject.123", projection))
 
+        fetch.subscribe_mock.assert_called_once_with(
+            f"the_nats_env_subject_prefix.some_subject.123", ordered_consumer=True
+        )
         fetch.ensure_consumer_is_deleted_mock.assert_called_once()
         self.assertEqual(result, {"count": 3})
 
@@ -59,6 +70,7 @@ class FetchTests(unittest.TestCase):
             handlers={"TheEvent": lambda state, _: {"count": state["count"] + 1}},
         )
         fetch = TestableFetch(
+            nats_prefix="the_nats_env_subject_prefix.",
             messages_to_return=[
                 {"type": "TheEvent", "data": {}},  # seq 1
                 {"type": "TheEvent", "data": {}},  # seq 2
@@ -69,6 +81,9 @@ class FetchTests(unittest.TestCase):
 
         result = asyncio.run(fetch.fetch("some_subject.123", projection, until_seq=2))
 
+        fetch.subscribe_mock.assert_called_once_with(
+            f"the_nats_env_subject_prefix.some_subject.123", ordered_consumer=True
+        )
         fetch.ensure_consumer_is_deleted_mock.assert_called_once()
         self.assertEqual(result, {"count": 2})
 
@@ -80,6 +95,7 @@ class FetchTests(unittest.TestCase):
             handlers={"TheEvent": lambda state, _: {"count": state["count"] + 1}},
         )
         fetch = TestableFetch(
+            nats_prefix="the_nats_env_subject_prefix.",
             messages_to_return=[
                 {"type": "TheEvent", "data": {}},  # seq 1
                 {"type": "UnrelatedEvent", "data": {}},  # seq 2
@@ -90,30 +106,34 @@ class FetchTests(unittest.TestCase):
 
         result = asyncio.run(fetch.fetch("some_subject.123", projection, until_seq=3))
 
+        fetch.subscribe_mock.assert_called_once_with(
+            f"the_nats_env_subject_prefix.some_subject.123", ordered_consumer=True
+        )
         fetch.ensure_consumer_is_deleted_mock.assert_called_once()
         self.assertEqual(result, {"count": 2})
 
 
 class TestableFetch(Fetch):
-    def __init__(self, messages_to_return=[]):
+    def __init__(
+        self, messages_to_return=[], nats_prefix="the_nats_env_subject_prefix."
+    ):
         self.ensure_consumer_is_deleted_mock = mock.AsyncMock()
         self._ensure_consumer_is_deleted = self.ensure_consumer_is_deleted_mock
-        self.jetstrean_client_mock = mock.Mock(
-            subscribe=mock.AsyncMock(
-                return_value=mock.AsyncMock(
-                    messages=self._create_messages_iterator(
-                        subject="some_subject_value_not_used",
-                        messages=messages_to_return,
-                    ),
-                    consumer_info=mock.AsyncMock(
-                        return_value=mock.Mock(
-                            num_pending=len(messages_to_return), delivered=None
-                        )
-                    ),
-                )
+        self.subscribe_mock = mock.AsyncMock(
+            return_value=mock.AsyncMock(
+                messages=self._create_messages_iterator(
+                    subject="some_subject_value_not_used",
+                    messages=messages_to_return,
+                ),
+                consumer_info=mock.AsyncMock(
+                    return_value=mock.Mock(
+                        num_pending=len(messages_to_return), delivered=None
+                    )
+                ),
             )
         )
-        super().__init__(self.jetstrean_client_mock, "the_prefix_doesnt_matter")
+        self.jetstrean_client_mock = mock.Mock(subscribe=self.subscribe_mock)
+        super().__init__(self.jetstrean_client_mock, nats_prefix)
 
     async def _create_messages_iterator(self, subject, messages):
         for index, message in enumerate(messages):


### PR DESCRIPTION
Added the option to specify until_seq to fetch which will stop including messages in the projection when their stream sequence number goes over what's specified in until_seq.

Had a go at adding unit test for fetch, @alexcannan I did not noticed that there were already tests in the project, I usually add them next to the file that is being tested (e.g. fetch, fetch.test), so I didn't notice that there was a test folder in the project initially and that it was using pytest. I moved the fetch tests to tests/ and used the same naming pattern.

I used unittest and unittest.mock. The tests for fetch don't need any infra to run, I ran them with `python -m unittest discover -s test -p "fetch*" -v`. You'll notice that I'm specifying a pattern that explicitly excludes the other test.

If you think it's worth it I can rewrite them using pytest (although I found using unittest.mock very reasonable, this was my first try).

I also caught two bugs during this exercise, one was that the the method to ensure that the consumer was deleted wouldn't run in some scenarios and the other had to do with the operator precedence here:
`consumer_info.num_pending or 0 + consumer_info.delivered.consumer_seq if consumer_info.delivered else 0`.
![image](https://github.com/user-attachments/assets/cdcea9c8-59c1-4db0-828a-90ec48c412a7)

